### PR TITLE
为redis-shiro加上二级缓存

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.crazycake</groupId>
@@ -8,7 +8,9 @@
 	<packaging>jar</packaging>
 
 	<name>shiro-redis</name>
-	<description>shiro only provide the support of ehcache and concurrentHashMap. Here is an implement of redis cache can be used by shiro. Hope it will help you!</description>
+	<description>shiro only provide the support of ehcache and concurrentHashMap. Here is an implement of redis cache
+		can be used by shiro. Hope it will help you!
+	</description>
 	<url>https://github.com/alexxiyang/shiro-redis</url>
 
 	<properties>
@@ -44,6 +46,7 @@
 			<version>1.2.1</version>
 		</dependency>
 
+
 		<!-- Testing -->
 		<dependency>
 			<groupId>junit</groupId>
@@ -64,6 +67,12 @@
 			<scope>test</scope>
 		</dependency>
 
+
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava-jdk5</artifactId>
+			<version>17.0</version>
+		</dependency>
 	</dependencies>
 
 
@@ -82,7 +91,7 @@
 		<developerConnection>scm:git:https://github.com/alexxiyang/shiro-redis.git</developerConnection>
 		<url>https://github.com/alexxiyang/shiro-redis.git</url>
 	</scm>
-    <!--
+
 	<distributionManagement>
 		<repository>
 			<id>nexus-releases</id>
@@ -90,7 +99,7 @@
 			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
 		</repository>
 	</distributionManagement>
-    -->
+
 	<build>
 		<finalName>shiro-redis</finalName>
 		<plugins>
@@ -119,22 +128,23 @@
 			</activation>
 
 			<properties>
-				<gpg.keyname>D2CB8A03</gpg.keyname>	<!-- GPG Key ID to use for signing -->
+				<gpg.keyname>D2CB8A03</gpg.keyname>
+				<!-- GPG Key ID to use for signing -->
 				<release.username>alexxiyang</release.username>
 			</properties>
 
 			<build>
 				<plugins>
-					<!-- Enable signing of the artifacts For gpg:sign-and-deploy-file it's 
-						necessary to have a <server> with the repositoryId provided or id="remote-repository" 
-						defined in settings.xml (it contains the repository's login, psw) Signing: 
-						mvn gpg:sign-and-deploy-file -DpomFile=target/myapp-1.0.pom \ > -Dfile=target/myapp-1.0.jar 
-						\ > -Durl=http://oss.sonatype.org/content/repositories/malyvelky/ \ > -DrepositoryId=sonatype_oss 
-						Note normally it uses the defaul key but we can ovveride it by either setting 
-						the property gpg.keyname (done in this POM) or by providing -Dkeyname=66AE163A 
-						on the command line. OR directly w/ gpg: gpg -u 66AE163A - -sign - -detach-sign 
-						-a target/dbunit-embeddedderby-parenttest.jar Note: "mvn gpg:sign" results 
-						in NPE with v 1.o-a.-4, use "mvn package gpg:sign" instead; see the issue 
+					<!-- Enable signing of the artifacts For gpg:sign-and-deploy-file it's
+						necessary to have a <server> with the repositoryId provided or id="remote-repository"
+						defined in settings.xml (it contains the repository's login, psw) Signing:
+						mvn gpg:sign-and-deploy-file -DpomFile=target/myapp-1.0.pom \ > -Dfile=target/myapp-1.0.jar
+						\ > -Durl=http://oss.sonatype.org/content/repositories/malyvelky/ \ > -DrepositoryId=sonatype_oss
+						Note normally it uses the defaul key but we can ovveride it by either setting
+						the property gpg.keyname (done in this POM) or by providing -Dkeyname=66AE163A
+						on the command line. OR directly w/ gpg: gpg -u 66AE163A - -sign - -detach-sign
+						-a target/dbunit-embeddedderby-parenttest.jar Note: "mvn gpg:sign" results
+						in NPE with v 1.o-a.-4, use "mvn package gpg:sign" instead; see the issue
 						MGPG-18 -->
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
@@ -157,11 +167,5 @@
 
 	</profiles>
 
-    <distributionManagement>
-        <repository>
-            <id>easyway</id>
-            <url>http://192.168.70.105:8981/nexus/content/repositories/easyway</url>
-        </repository>
-</distributionManagement>
-
+	
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.crazycake</groupId>
 	<artifactId>shiro-redis</artifactId>
-	<version>2.4.2.1-RELEASE</version>
+	<version>2.4.2.3</version>
 	<packaging>jar</packaging>
 
 	<name>shiro-redis</name>
@@ -21,6 +21,7 @@
 		<license>
 			<name>The Apache Software License, Version 2.0</name>
 			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+
 			<distribution>repo</distribution>
 		</license>
 	</licenses>
@@ -81,6 +82,7 @@
 		<developerConnection>scm:git:https://github.com/alexxiyang/shiro-redis.git</developerConnection>
 		<url>https://github.com/alexxiyang/shiro-redis.git</url>
 	</scm>
+    <!--
 	<distributionManagement>
 		<repository>
 			<id>nexus-releases</id>
@@ -88,6 +90,7 @@
 			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
 		</repository>
 	</distributionManagement>
+    -->
 	<build>
 		<finalName>shiro-redis</finalName>
 		<plugins>
@@ -153,4 +156,12 @@
 		</profile>
 
 	</profiles>
+
+    <distributionManagement>
+        <repository>
+            <id>easyway</id>
+            <url>http://192.168.70.105:8981/nexus/content/repositories/easyway</url>
+        </repository>
+</distributionManagement>
+
 </project>

--- a/src/main/java/org/crazycake/shiro/RedisCache.java
+++ b/src/main/java/org/crazycake/shiro/RedisCache.java
@@ -12,6 +12,7 @@ import org.apache.shiro.cache.CacheException;
 import org.apache.shiro.util.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import redis.clients.util.SafeEncoder;
 
 public class RedisCache<K, V> implements Cache<K, V> {
 	
@@ -75,12 +76,12 @@ public class RedisCache<K, V> implements Cache<K, V> {
 	 * @param key
 	 * @return
 	 */
-	private byte[] getByteKey(K key){
+	private String getByteKey(K key){
 		if(key instanceof String){
 			String preKey = this.keyPrefix + key;
-    		return preKey.getBytes();
+    		return preKey;
     	}else{
-    		return SerializeUtils.serialize(key);
+    		return SafeEncoder.encode(SerializeUtils.serialize(key));
     	}
 	}
  	

--- a/src/main/java/org/crazycake/shiro/RedisManager.java
+++ b/src/main/java/org/crazycake/shiro/RedisManager.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.util.SafeEncoder;
 
 public class RedisManager {
 	
@@ -47,11 +48,11 @@ public class RedisManager {
 	 * @param key
 	 * @return
 	 */
-	public byte[] get(byte[] key){
+	public byte[] get(String key){
 		byte[] value = null;
 		Jedis jedis = jedisPool.getResource();
 		try{
-			value = jedis.get(key);
+			value = jedis.get(SafeEncoder.encode(key));
 		}finally{
 			jedisPool.returnResource(jedis);
 		}
@@ -64,10 +65,10 @@ public class RedisManager {
 	 * @param value
 	 * @return
 	 */
-	public byte[] set(byte[] key,byte[] value){
+	public byte[] set(String key,byte[] value){
 		Jedis jedis = jedisPool.getResource();
 		try{
-			jedis.set(key,value);
+			jedis.set(SafeEncoder.encode(key),value);
 			if(this.expire != 0){
 				jedis.expire(key, this.expire);
 		 	}
@@ -84,10 +85,11 @@ public class RedisManager {
 	 * @param expire
 	 * @return
 	 */
-	public byte[] set(byte[] key,byte[] value,int expire){
+	public byte[] set(String key,byte[] value,int expire){
 		Jedis jedis = jedisPool.getResource();
 		try{
-			jedis.set(key,value);
+
+			jedis.set(SafeEncoder.encode(key),value);
 			if(expire != 0){
 				jedis.expire(key, expire);
 		 	}
@@ -101,10 +103,10 @@ public class RedisManager {
 	 * del
 	 * @param key
 	 */
-	public void del(byte[] key){
+	public void del(String key){
 		Jedis jedis = jedisPool.getResource();
 		try{
-			jedis.del(key);
+			jedis.del(SafeEncoder.encode(key));
 		}finally{
 			jedisPool.returnResource(jedis);
 		}
@@ -145,7 +147,7 @@ public class RedisManager {
 		Set<byte[]> keys = null;
 		Jedis jedis = jedisPool.getResource();
 		try{
-			keys = jedis.keys(pattern.getBytes());
+			keys = jedis.keys(SafeEncoder.encode(pattern));
 		}finally{
 			jedisPool.returnResource(jedis);
 		}

--- a/src/main/java/org/crazycake/shiro/RedisSessionDAO.java
+++ b/src/main/java/org/crazycake/shiro/RedisSessionDAO.java
@@ -4,7 +4,12 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import org.apache.shiro.session.Session;
 import org.apache.shiro.session.UnknownSessionException;
 import org.apache.shiro.session.mgt.eis.AbstractSessionDAO;
@@ -19,86 +24,129 @@ public class RedisSessionDAO extends AbstractSessionDAO {
 	 * shiro-redis的session对象前缀
 	 */
 	private RedisManager redisManager;
-	
+
+	private LoadingCache<Serializable, Session> sessionCache = CacheBuilder.newBuilder().maximumSize(1024).expireAfterWrite(3, TimeUnit.MINUTES).build(
+			new CacheLoader<Serializable, Session>() {
+				public Session load(Serializable key) {
+					long start = System.currentTimeMillis();
+					Session s = (Session) SerializeUtils.deserialize(redisManager.get(getByteKey(key)));
+					logger.info("get session from redis" + key.toString() + " token time is:" + (System.currentTimeMillis() - start));
+					return s;
+				}
+			});
+
+
 	/**
-	 * The Redis key prefix for the sessions 
+	 * The Redis key prefix for the sessions
 	 */
 	private String keyPrefix = "shiro_redis_session:";
-	
+
+	@Override
+	protected Serializable doCreate(Session session) {
+		long start = System.currentTimeMillis();
+		Serializable sessionId = generateSessionId(session);
+		this.assignSessionId(session, sessionId);
+
+		this.saveSession(session);
+		if (logger.isDebugEnabled()) {
+			logger.debug("Create session :" + (System.currentTimeMillis() - start));
+		}
+		return sessionId;
+	}
+
+
 	@Override
 	public void update(Session session) throws UnknownSessionException {
+		long start = System.currentTimeMillis();
 		this.saveSession(session);
+		if (logger.isDebugEnabled()) {
+			logger.debug("update session :" + (System.currentTimeMillis() - start));
+		}
 	}
-	
+
 	/**
 	 * save session
+	 *
 	 * @param session
 	 * @throws UnknownSessionException
 	 */
-	private void saveSession(Session session) throws UnknownSessionException{
-		if(session == null || session.getId() == null){
+	private void saveSession(Session session) throws UnknownSessionException {
+		long start = System.currentTimeMillis();
+		if (session == null || session.getId() == null) {
 			logger.error("session or session id is null");
 			return;
 		}
-		
+
 		String key = getByteKey(session.getId());
 		byte[] value = SerializeUtils.serialize(session);
-		session.setTimeout(redisManager.getExpire()*1000);		
+		session.setTimeout(redisManager.getExpire() * 1000);
 		this.redisManager.set(key, value, redisManager.getExpire());
+		if (logger.isDebugEnabled()) {
+			logger.debug("saveSession :" + (System.currentTimeMillis() - start));
+		}
 	}
 
 	@Override
 	public void delete(Session session) {
-		if(session == null || session.getId() == null){
+		long start = System.currentTimeMillis();
+		if (session == null || session.getId() == null) {
 			logger.error("session or session id is null");
 			return;
 		}
 		redisManager.del(this.getByteKey(session.getId()));
-
+		if (logger.isDebugEnabled()) {
+			logger.debug("delete :" + (System.currentTimeMillis() - start));
+		}
 	}
 
 	@Override
 	public Collection<Session> getActiveSessions() {
+		long start = System.currentTimeMillis();
 		Set<Session> sessions = new HashSet<Session>();
-		
+
 		Set<byte[]> keys = redisManager.keys(this.keyPrefix + "*");
-		if(keys != null && keys.size()>0){
-			for(byte[] key:keys){
-				Session s = (Session)SerializeUtils.deserialize(redisManager.get(SafeEncoder.encode(key)));
+		if (keys != null && keys.size() > 0) {
+			for (byte[] key : keys) {
+				Session s = (Session) SerializeUtils.deserialize(redisManager.get(SafeEncoder.encode(key)));
 				sessions.add(s);
 			}
 		}
-		
+		if (logger.isDebugEnabled()) {
+			logger.debug("getActiveSessions :" + (System.currentTimeMillis() - start));
+		}
 		return sessions;
 	}
 
-	@Override
-	protected Serializable doCreate(Session session) {
-		Serializable sessionId = this.generateSessionId(session);  
-        this.assignSessionId(session, sessionId);
-        this.saveSession(session);
-		return sessionId;
-	}
 
 	@Override
 	protected Session doReadSession(Serializable sessionId) {
-		if(sessionId == null){
+		long start = System.currentTimeMillis();
+		if (sessionId == null) {
 			logger.error("session id is null");
 			return null;
 		}
-		
-		Session s = (Session)SerializeUtils.deserialize(redisManager.get(this.getByteKey(sessionId)));
+
+		Session s = null; // (Session) SerializeUtils.deserialize(redisManager.get(this.getByteKey(sessionId)));
+		try {
+			s = sessionCache.get(sessionId);
+			if (logger.isDebugEnabled()) {
+				logger.debug("doReadSession session id:" + sessionId.toString() + " token time is:" + (System.currentTimeMillis() - start));
+			}
+		} catch (ExecutionException e) {
+			logger.error(e.getMessage(), e);
+			return s;
+		}
 		return s;
 	}
-	
+
 	/**
 	 * 获得byte[]型的key
-	 * @param key
+	 *
+	 * @param sessionId
 	 * @return
 	 */
-	private String getByteKey(Serializable sessionId){
-		String preKey = this.keyPrefix + sessionId;
-		return preKey;
+	private String getByteKey(Serializable sessionId) {
+		return this.keyPrefix + sessionId;
 	}
 
 	public RedisManager getRedisManager() {
@@ -107,7 +155,7 @@ public class RedisSessionDAO extends AbstractSessionDAO {
 
 	public void setRedisManager(RedisManager redisManager) {
 		this.redisManager = redisManager;
-		
+
 		/**
 		 * 初始化redisManager
 		 */
@@ -117,6 +165,7 @@ public class RedisSessionDAO extends AbstractSessionDAO {
 	/**
 	 * Returns the Redis session keys
 	 * prefix.
+	 *
 	 * @return The prefix
 	 */
 	public String getKeyPrefix() {
@@ -124,13 +173,14 @@ public class RedisSessionDAO extends AbstractSessionDAO {
 	}
 
 	/**
-	 * Sets the Redis sessions key 
+	 * Sets the Redis sessions key
 	 * prefix.
+	 *
 	 * @param keyPrefix The prefix
 	 */
 	public void setKeyPrefix(String keyPrefix) {
 		this.keyPrefix = keyPrefix;
 	}
-	
-	
+
+
 }

--- a/src/main/java/org/crazycake/shiro/RedisSessionDAO.java
+++ b/src/main/java/org/crazycake/shiro/RedisSessionDAO.java
@@ -10,6 +10,7 @@ import org.apache.shiro.session.UnknownSessionException;
 import org.apache.shiro.session.mgt.eis.AbstractSessionDAO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import redis.clients.util.SafeEncoder;
 
 public class RedisSessionDAO extends AbstractSessionDAO {
 
@@ -40,7 +41,7 @@ public class RedisSessionDAO extends AbstractSessionDAO {
 			return;
 		}
 		
-		byte[] key = getByteKey(session.getId());
+		String key = getByteKey(session.getId());
 		byte[] value = SerializeUtils.serialize(session);
 		session.setTimeout(redisManager.getExpire()*1000);		
 		this.redisManager.set(key, value, redisManager.getExpire());
@@ -63,7 +64,7 @@ public class RedisSessionDAO extends AbstractSessionDAO {
 		Set<byte[]> keys = redisManager.keys(this.keyPrefix + "*");
 		if(keys != null && keys.size()>0){
 			for(byte[] key:keys){
-				Session s = (Session)SerializeUtils.deserialize(redisManager.get(key));
+				Session s = (Session)SerializeUtils.deserialize(redisManager.get(SafeEncoder.encode(key)));
 				sessions.add(s);
 			}
 		}
@@ -95,9 +96,9 @@ public class RedisSessionDAO extends AbstractSessionDAO {
 	 * @param key
 	 * @return
 	 */
-	private byte[] getByteKey(Serializable sessionId){
+	private String getByteKey(Serializable sessionId){
 		String preKey = this.keyPrefix + sessionId;
-		return preKey.getBytes();
+		return preKey;
 	}
 
 	public RedisManager getRedisManager() {

--- a/src/main/java/org/crazycake/shiro/SerializeUtils.java
+++ b/src/main/java/org/crazycake/shiro/SerializeUtils.java
@@ -10,18 +10,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SerializeUtils {
-	
+
 	private static Logger logger = LoggerFactory.getLogger(SerializeUtils.class);
-	
+
 	/**
 	 * 反序列化
+	 *
 	 * @param bytes
 	 * @return
 	 */
 	public static Object deserialize(byte[] bytes) {
-		
+		long start = System.currentTimeMillis();
 		Object result = null;
-		
+
 		if (isEmpty(bytes)) {
 			return null;
 		}
@@ -32,39 +33,41 @@ public class SerializeUtils {
 				ObjectInputStream objectInputStream = new ObjectInputStream(byteStream);
 				try {
 					result = objectInputStream.readObject();
-				}
-				catch (ClassNotFoundException ex) {
+				} catch (ClassNotFoundException ex) {
 					throw new Exception("Failed to deserialize object type", ex);
 				}
-			}
-			catch (Throwable ex) {
+			} catch (Throwable ex) {
 				throw new Exception("Failed to deserialize", ex);
 			}
 		} catch (Exception e) {
-			logger.error("Failed to deserialize",e);
+			logger.error("Failed to deserialize", e);
+		}
+		if (logger.isDebugEnabled()) {
+			logger.debug("deserialize object time is:" + (System.currentTimeMillis() - start));
 		}
 		return result;
 	}
-	
+
 	public static boolean isEmpty(byte[] data) {
 		return (data == null || data.length == 0);
 	}
 
 	/**
 	 * 序列化
+	 *
 	 * @param object
 	 * @return
 	 */
 	public static byte[] serialize(Object object) {
-		
+		long start = System.currentTimeMillis();
 		byte[] result = null;
-		
+
 		if (object == null) {
 			return new byte[0];
 		}
 		try {
 			ByteArrayOutputStream byteStream = new ByteArrayOutputStream(128);
-			try  {
+			try {
 				if (!(object instanceof Serializable)) {
 					throw new IllegalArgumentException(SerializeUtils.class.getSimpleName() + " requires a Serializable payload " +
 							"but received an object of type [" + object.getClass().getName() + "]");
@@ -72,13 +75,15 @@ public class SerializeUtils {
 				ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteStream);
 				objectOutputStream.writeObject(object);
 				objectOutputStream.flush();
-				result =  byteStream.toByteArray();
-			}
-			catch (Throwable ex) {
+				result = byteStream.toByteArray();
+			} catch (Throwable ex) {
 				throw new Exception("Failed to serialize", ex);
 			}
 		} catch (Exception ex) {
-			logger.error("Failed to serialize",ex);
+			logger.error("Failed to serialize", ex);
+		}
+		if (logger.isDebugEnabled()) {
+			logger.debug("serialize object time is:" + (System.currentTimeMillis() - start));
 		}
 		return result;
 	}


### PR DESCRIPTION
在shiro的一次认证过程中会调用10次左右的 doReadSession，如果使用内存缓存这个问题不大。但是如果使用redis，而且子网络情况不是特别好的情况下这就成为问题了。我简单在我的环境下测试了一下。一次redis请求需要80 ~ 100 ms， 一下来10次，我们一次认证就需要10 \* 100 = 1000 ms, 这个就是我们无法接受的了。

所以使用guava的缓存机制加上了短时间的缓存，我初步写死成了3秒，这样就可以确保一次认证只是访问一次redis。这样就大大的加快了这个验证的过程。 不过这个参数是可以通过参数进行设定。
