### PR TITLE
1、 在org.crazycake.shiro.RedisCache#put(key,value)时, 允许设置超时时间。

### DIFF
--- a/src/main/java/org/crazycake/shiro/RedisCache.java
+++ b/src/main/java/org/crazycake/shiro/RedisCache.java
@@ -66,7 +66,7 @@ public class RedisCache<K, V> implements Cache<K, V> {
 		logger.debug("put key [" + key + "]");
 		try {
 			Object redisCacheKey = getRedisCacheKey(key);
-			redisManager.set(keySerializer.serialize(redisCacheKey), valueSerializer.serialize(value));
+			redisManager.set(keySerializer.serialize(redisCacheKey), valueSerializer.serialize(value), redisManager.getExpire());
 			return value;
 		} catch (SerializationException e) {
 			throw new CacheException(e);

--- a/src/main/java/org/crazycake/shiro/RedisCacheManager.java
+++ b/src/main/java/org/crazycake/shiro/RedisCacheManager.java
@@ -32,7 +32,7 @@ public class RedisCacheManager implements CacheManager {
 		Cache cache = caches.get(name);
 		
 		if (cache == null) {
-			cache = new RedisCache<K, V>(redisManager, keySerializer, valueSerializer, keyPrefix);
+			cache = new RedisCache<K, V>(redisManager, keySerializer, valueSerializer, keyPrefix + name + ":");
 			caches.put(name, cache);
 		}
 		return cache;


### PR DESCRIPTION
2、 在org.crazycake.shiro.RedisCacheManager#getCache(name)时, 将name扩展至key的前缀keyPrefix, 防止在获取不同name的Cache 时冲突。