### PR TITLE
提升jedis版本到3.1.0 解决高版本jedis导致 调用 redisSessionDao 的getActiveSessions 方法导致崩溃问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,8 @@ shiro only provide the support of ehcache and concurrentHashMap. Here is an impl
 
 Official documentation [is located here](http://alexxiyang.github.io/shiro-redis/).
 
+## 发现了个原作者的bug
+
+由于jedis3.0改变了api,导致 直接调用作者的 redisSessionDao的getActiviesSessions方法会导致崩溃
+所以我做出了修改,并向作者发起pr pr未合并之前 请引用我发布的版本
+

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<dependency>
 			<groupId>redis.clients</groupId>
 			<artifactId>jedis</artifactId>
-			<version>2.9.0</version>
+			<version>3.1.0</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>org.crazycake</groupId>
+	<groupId>com.czq</groupId>
 	<artifactId>shiro-redis</artifactId>
 	<version>3.2.3</version>
 	<packaging>jar</packaging>

--- a/src/main/java/org/crazycake/shiro/RedisClusterManager.java
+++ b/src/main/java/org/crazycake/shiro/RedisClusterManager.java
@@ -136,7 +136,7 @@ public class RedisClusterManager implements IRedisManager {
                 scanResult = jedis.scan(cursor, params);
                 keys.addAll(scanResult.getResult());
                 cursor = scanResult.getCursorAsBytes();
-            } while (scanResult.getStringCursor().compareTo(ScanParams.SCAN_POINTER_START) > 0);
+            } while (scanResult.getCursor().compareTo(ScanParams.SCAN_POINTER_START) > 0);
         } finally {
             jedis.close();
         }
@@ -157,7 +157,7 @@ public class RedisClusterManager implements IRedisManager {
                 scanResult = jedis.scan(cursor, params);
                 dbSize++;
                 cursor = scanResult.getCursorAsBytes();
-            } while (scanResult.getStringCursor().compareTo(ScanParams.SCAN_POINTER_START) > 0);
+            } while (scanResult.getCursor().compareTo(ScanParams.SCAN_POINTER_START) > 0);
         } finally {
             jedis.close();
         }


### PR DESCRIPTION
解决高版本jedis导致
调用 redisSessionDao 的getActiveSessions 方法导致崩溃问题


请合并我的pr并且发布release,谢谢,否则这个方法无法调用会崩溃