### PR TITLE
Update RedisSentinelManager.java

### DIFF
--- a/src/main/java/org/crazycake/shiro/RedisSentinelManager.java
+++ b/src/main/java/org/crazycake/shiro/RedisSentinelManager.java
@@ -26,7 +26,7 @@ public class RedisSentinelManager extends WorkAloneRedisManager implements IRedi
 
 	private int database = Protocol.DEFAULT_DATABASE;
 
-	private JedisSentinelPool jedisPool;
+	private volatile JedisSentinelPool jedisPool;
 
 	@Override
 	protected Jedis getJedis() {


### PR DESCRIPTION
private volatile JedisCluster jedisCluster = null;
使用双重检查模式的属性应使用volatile修饰，作者这里应该是忘记了